### PR TITLE
Execute checks PRE_LINK.

### DIFF
--- a/CPPCheck.cmake
+++ b/CPPCheck.cmake
@@ -44,7 +44,7 @@ function (_cppcheck_add_checks_to_target SOURCES_VAR TARGET OPTIONS_VAR)
     endif (ADD_CHECKS_OPTIONS_COMMENT)
 
     add_custom_command (TARGET ${TARGET}
-                        POST_BUILD
+                        PRE_LINK
                         COMMAND
                         ${CPPCHECK_EXECUTABLE}
                         ARGS


### PR DESCRIPTION
This ensures that they occurr after source files have been generated
but before the final target was linked, so that if errors are generated
as a result of the check process then the target won't be marked
as successfully built.
