### PR TITLE
Some refactoring

### DIFF
--- a/CPPCheck.cmake
+++ b/CPPCheck.cmake
@@ -8,6 +8,7 @@
 
 include (CMakeParseArguments)
 include (${CMAKE_CURRENT_LIST_DIR}/determine-header-language/DetermineHeaderLanguage.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/util/CppCheckUtil.cmake)
 
 set (CPPCHECK_COMMON_OPTIONS
      --quiet
@@ -68,37 +69,6 @@ function (_validate_cppcheck CONTINUE)
 
 endfunction (_validate_cppcheck)
 
-function (_filter_out_generated_sources RESULT_VARIABLE)
-
-    set (FILTER_OUT_MUTLIVAR_OPTIONS SOURCES)
-
-    cmake_parse_arguments (FILTER_OUT
-                           ""
-                           ""
-                           "${FILTER_OUT_MUTLIVAR_OPTIONS}"
-                           ${ARGN})
-
-    set (${RESULT_VARIABLE} PARENT_SCOPE)
-    set (FILTERED_SOURCES)
-
-    foreach (SOURCE ${FILTER_OUT_SOURCES})
-
-        get_property (SOURCE_IS_GENERATED
-                      SOURCE ${SOURCE}
-                      PROPERTY GENERATED)
-
-        if (NOT SOURCE_IS_GENERATED)
-
-            list (APPEND FILTERED_SOURCES ${SOURCE})
-
-        endif (NOT SOURCE_IS_GENERATED)
-
-    endforeach ()
-
-    set (${RESULT_VARIABLE} ${FILTERED_SOURCES} PARENT_SCOPE)
-
-endfunction (_filter_out_generated_sources)
-
 function (_cppcheck_get_commandline COMMANDLINE_RETURN)
 
     set (COMMANDLINE_MULTIVAR_OPTIONS SOURCES OPTIONS)
@@ -158,65 +128,18 @@ function (_cppcheck_add_checks_to_target TARGET
          DEFINES
          CPP_IDENTIFIERS)
 
-    cmake_parse_arguments (ADD_CHECKS_TO_TARGET
+    cmake_parse_arguments (ADD_CHECKS
                            "${ADD_CHECKS_OPTIONS}"
                            "${ADD_CHECKS_SINGLEVAR_OPTIONS}"
                            "${ADD_CHECKS_MULTIVAR_OPTIONS}"
                            ${ARGN})
 
-    set (DETECT_LANGUAGE_SOURCES)
-    set (C_HEADERS)
-    set (CXX_HEADERS)
-
-    foreach (SOURCE ${ADD_CHECKS_TO_TARGET_SOURCES})
-
-        set (LANGUAGE ${ADD_CHECKS_TO_TARGET_FORCE_LANGUAGE})
-
-        if (NOT LANGUAGE)
-
-            set (INCLUDES ${ADD_CHECKS_TO_TARGET_INCLUDES})
-            set (CPP_IDENTIFIERS ${ADD_CHECKS_TO_TARGET_CPP_IDENTIFIERS})
-            polysquare_determine_language_for_source (${SOURCE}
-                                                      LANGUAGE
-                                                      SOURCE_WAS_HEADER
-                                                      INCLUDES ${INCLUDES})
-
-            # Scan this source for headers, we'll need them later
-            if (NOT SOURCE_WAS_HEADER)
-
-                polysquare_scan_source_for_headers (SOURCE ${SOURCE}
-                                                    INCLUDES ${INCLUDES}
-                                                    CPP_IDENTIFIERS
-                                                    ${CPP_IDENTIFIERS})
-
-            endif (NOT SOURCE_WAS_HEADER)
-
-        endif (NOT LANGUAGE)
-
-        list (FIND LANGUAGE "C" C_INDEX)
-        list (FIND LANGUAGE "CXX" CXX_INDEX)
-
-        if (NOT C_INDEX EQUAL -1)
-
-            list (APPEND C_HEADERS ${SOURCE})
-
-        endif (NOT C_INDEX EQUAL -1)
-
-        if (NOT CXX_INDEX EQUAL -1)
-
-            list (APPEND CXX_HEADERS ${SOURCE})
-
-        endif (NOT CXX_INDEX EQUAL -1)
-
-    endforeach ()
-
-    # For known languages, no special options
-    _cppcheck_add_normal_check_command (${TARGET} ${WHEN}
-                                        SOURCES ${KNOWN_LANGUAGE_SOURCES}
-                                        OPTIONS ${ADD_CHECKS_TO_TARGET_OPTIONS})
-
-    set (C_LANGUAGE_OPTION)
-    set (CXX_LANGUAGE_OPTION)
+    _polysquare_forward_options (ADD_CHECKS
+                                 SORT_SOURCES_OPTIONS
+                                 SINGLEVAR_ARGS FORCE_LANGUAGE
+                                 MULTIVAR_ARGS SOURCES INCLUDES CPP_IDENTIFIERS)
+    _sort_sources_to_languages (C_SOURCES CXX_SOURCES
+                                ${SORT_SOURCES_OPTIONS})
 
     if (${CPPCHECK_VERSION} VERSION_GREATER 1.57)
 
@@ -227,48 +150,18 @@ function (_cppcheck_add_checks_to_target TARGET
 
     # For C headers, pass --language=c
     _cppcheck_add_normal_check_command (${TARGET} ${WHEN}
-                                        SOURCES ${C_HEADERS}
+                                        SOURCES ${C_SOURCES}
                                         OPTIONS
-                                        ${ADD_CHECKS_TO_TARGET_OPTIONS}
+                                        ${ADD_CHECKS_OPTIONS}
                                         ${C_LANGUAGE_OPTION})
 
     # For CXX headers, pass --language=c++ and -D__cplusplus
     _cppcheck_add_normal_check_command (${TARGET} ${WHEN}
-                                        SOURCES ${CXX_HEADERS}
+                                        SOURCES ${CXX_SOURCES}
                                         OPTIONS
-                                        ${ADD_CHECKS_TO_TARGET_OPTIONS}
+                                        ${ADD_CHECKS_OPTIONS}
                                         ${CXX_LANGUAGE_OPTION}
                                         -D__cplusplus)
-
-endfunction ()
-
-function (_append_to_global_property_unique PROPERTY ITEM)
-
-    get_property (GLOBAL_PROPERTY
-                  GLOBAL
-                  PROPERTY ${PROPERTY})
-
-    set (LIST_CONTAINS_ITEM FALSE)
-
-    foreach (LIST_ITEM ${GLOBAL_PROPERTY})
-
-        if (LIST_ITEM STREQUAL ${ITEM})
-
-            set (LIST_CONTAINS_ITEM TRUE)
-            break ()
-
-        endif (LIST_ITEM STREQUAL ${ITEM})
-
-    endforeach ()
-
-    if (NOT LIST_CONTAINS_ITEM)
-
-        set_property (GLOBAL
-                      APPEND
-                      PROPERTY ${PROPERTY}
-                      ${ITEM})
-
-    endif (NOT LIST_CONTAINS_ITEM)
 
 endfunction ()
 
@@ -307,64 +200,20 @@ function (cppcheck_add_to_unused_function_check WHICH)
                            "${UNUSED_CHECK_MULTIVAR_ARGS}"
                            ${ARGN})
 
-    set (FILTERED_CHECK_SOURCES)
-
-    # First case: We're checking generated sources, so
-    # we can just check all passed in sources.
-    if (UNUSED_CHECK_CHECK_GENERATED)
-
-        set (FILTERED_CHECK_SOURCES ${UNUSED_CHECK_SOURCES})
-
-    # Second case: We only want to check real sources,
-    # so filter out generated ones.
-    else (UNUSED_CHECK_CHECK_GENERATED)
-
-        _filter_out_generated_sources (FILTERED_CHECK_SOURCES
-                                       SOURCES ${UNUSED_CHECK_SOURCES})
-
-    endif (UNUSED_CHECK_CHECK_GENERATED)
+    _handle_check_generated_option (UNUSED_CHECK FILTERED_CHECK_SOURCES
+                                    SOURCES ${UNUSED_CHECK_SOURCES})
 
     _append_to_global_property_unique (CPPCHECK_UNUSED_FUNCTION_CHECK_NAMES
                                        ${WHICH})
 
-    foreach (SOURCE ${FILTERED_CHECK_SOURCES})
-
-        set_property (GLOBAL
-                      APPEND
-                      PROPERTY CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_SOURCES
-                      ${SOURCE})
-
-    endforeach ()
-
-    foreach (INCLUDE ${UNUSED_CHECK_INCLUDES})
-
-        set_property (GLOBAL
-                      APPEND
-                      PROPERTY CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_INCLUDES
-                      ${INCLUDE})
-
-    endforeach ()
-
-    foreach (DEFINE ${UNUSED_CHECK_DEFINES})
-
-        set_property (GLOBAL
-                      APPEND
-                      PROPERTY
-                      CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_DEFINES
-                      ${DEFINE})
-
-    endforeach ()
-
-    set (STAMPFILE ${CMAKE_CURRENT_BINARY_DIR}/${WHICH}.stamp)
-
-    foreach (TARGET ${UNUSED_CHECK_TARGETS})
-
-        set_property (GLOBAL
-                      APPEND
-                      PROPERTY CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_TARGETS
-                      ${TARGET})
-
-    endforeach ()
+    _append_to_global_property (CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_SOURCES
+                                LIST ${FILTERED_CHECK_SOURCES})
+    _append_to_global_property (CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_INCLUDES
+                                LIST ${UNUSED_CHECK_INCLUDES})
+    _append_to_global_property (CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_DEFINES
+                                LIST ${UNUSED_CHECK_DEFINES})
+    _append_to_global_property (CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_TARGETS
+                                LIST ${UNUSED_CHECK_TARGETS})
 
 endfunction (cppcheck_add_to_unused_function_check)
 
@@ -422,37 +271,28 @@ function (cppcheck_add_unused_function_check_with_name WHICH)
 
     endforeach ()
 
-    if (NOT HAS_UNUSED_FUNCTION_CHECK_WITH_THIS_NAME)
-
-        message (SEND_ERROR "No unused function check with name ${WHICH} exists")
-        return ()
-
-    endif (NOT HAS_UNUSED_FUNCTION_CHECK_WITH_THIS_NAME)
+    _assert_set (HAS_UNUSED_FUNCTION_CHECK_WITH_THIS_NAME
+                 "No unused function check with name ${WHICH} exists")
 
     get_property (_cppcheck_unused_function_sources_set
                   GLOBAL
                   PROPERTY CPPCHECK_${WHICH}_UNUSED_FUNCTION_CHECK_SOURCES
                   SET)
 
-    if (NOT _cppcheck_unused_function_sources_set)
-
-        message (SEND_ERROR "No unused function sources registered, "
-                            "they should be registered using "
-                            "cppcheck_add_to_global_unused_function_check "
-                            "before calling "
-                            "cppcheck_add_global_unused_function_check_to_"
-                            "target")
-
-        return ()
-
-    endif (NOT _cppcheck_unused_function_sources_set)
+    _assert_set (_cppcheck_unused_function_sources_set
+                 "No unused function sources registered, "
+                 "they should be registered using "
+                 "cppcheck_add_to_global_unused_function_check "
+                 "before calling "
+                 "cppcheck_add_global_unused_function_check_to_"
+                 "target")
 
     set (OPTIONAL_OPTIONS WARN_ONLY)
     set (MULTIVALUE_OPTIONS
          INCLUDES
          DEFINES)
 
-    cmake_parse_arguments (ADD_GLOBAL_UNUSED_FUNCTION_CHECK
+    cmake_parse_arguments (UNUSED_CHECK
                            "${OPTIONAL_OPTIONS}"
                            ""
                            "${MULTIVALUE_OPTIONS}"
@@ -484,29 +324,22 @@ function (cppcheck_add_unused_function_check_with_name WHICH)
 
     endif (${CPPCHECK_VERSION} VERSION_GREATER 1.57)
 
-    if (NOT ADD_GLOBAL_UNUSED_FUNCTION_CHECK_WARN_ONLY)
+    _add_switch (OPTION UNUSED_CHECK_WARN_ONLY
+                 ON --error-exitcode=1)
 
-        list (APPEND OPTIONS --error-exitcode=1)
-
-    endif (NOT ADD_GLOBAL_UNUSED_FUNCTION_CHECK_WARN_ONLY)
-
-    list (APPEND ADD_GLOBAL_UNUSED_FUNCTION_CHECK_INCLUDES
+    list (APPEND UNUSED_CHECK_INCLUDES
           ${_cppcheck_unused_function_includes})
 
-    foreach (_include ${ADD_GLOBAL_UNUSED_FUNCTION_CHECK_INCLUDES})
+    _append_each_to_options_with_prefix (OPTIONS -I
+                                         LIST
+                                         ${UNUSED_CHECK_INCLUDES})
 
-        list (APPEND OPTIONS -I${_include})
-
-    endforeach (_include)
-
-    list (APPEND ADD_GLOBAL_UNUSED_FUNCTION_CHECK_DEFINES
+    list (APPEND UNUSED_CHECK_DEFINES
           ${_cppcheck_unused_function_definitions})
 
-    foreach (_definition ${ADD_GLOBAL_UNUSED_FUNCTION_CHECK_DEFINES})
-
-        list (APPEND OPTIONS -D${_definition})
-
-    endforeach ()
+    _append_each_to_options_with_prefix (OPTIONS -D
+                                         LIST
+                                         ${UNUSED_CHECK_DEFINES})
 
     _cppcheck_get_commandline (CPPCHECK_COMMAND
                                SOURCES ${_cppcheck_unused_function_sources}
@@ -557,8 +390,6 @@ function (cppcheck_sources TARGET)
 
     _validate_cppcheck (CPPCHECK_AVAILABLE)
 
-    message ("CAN RUN CPPCHECK ${CPPCHECK_AVAILABLE} ${ARGN}")
-
     if (NOT CPPCHECK_AVAILABLE)
 
         return ()
@@ -583,85 +414,36 @@ function (cppcheck_sources TARGET)
                            "${MULTIVALUE_OPTIONS}"
                            ${ARGN})
 
-    set (FILTERED_CHECK_SOURCES)
+    _handle_check_generated_option (CPPCHECK FILTERED_CHECK_SOURCES
+                                    SOURCES ${CPPCHECK_SOURCES})
 
-    # First case: We're checking generated sources, so
-    # we can just check all passed in sources.
-    if (CPPCHECK_CHECK_GENERATED)
-
-        set (FILTERED_CHECK_SOURCES ${CPPCHECK_SOURCES})
-
-    # Second case: We only want to check real sources,
-    # so filter out generated ones.
-    else (CPPCHECK_CHECK_GENERATED)
-
-        _filter_out_generated_sources (FILTERED_CHECK_SOURCES
-                                       SOURCES ${CPPCHECK_SOURCES})
-
-    endif (CPPCHECK_CHECK_GENERATED)
-
-    # Figure out if this target is linkable. If it is a UTILITY
-    # target then we need to run the checks at the PRE_BUILD stage.
-    set (WHEN PRE_LINK)
-
-    get_property (TARGET_TYPE
-                  TARGET ${TARGET}
-                  PROPERTY TYPE)
-
-    if (TARGET_TYPE STREQUAL "UTILITY")
-
-        set (WHEN PRE_BUILD)
-
-    endif (TARGET_TYPE STREQUAL "UTILITY")
-
-    if (NOT FILTERED_CHECK_SOURCES)
-
-        message (FATAL_ERROR "SOURCES must be set to either native sources "
+    _assert_set (FILTERED_CHECK_SOURCES
+                 "SOURCES must be set to either native sources "
                  "or generated sources with the CHECK_GENERATED flag set "
                  "when using cppcheck_sources")
-
-    endif (NOT FILTERED_CHECK_SOURCES)
 
     set (CPPCHECK_OPTIONS
          ${CPPCHECK_COMMON_OPTIONS}
          --enable=performance
          --enable=portability)
 
-    if (NOT CPPCHECK_WARN_ONLY)
+    _add_switch (CPPCHECK_OPTIONS CPPCHECK_WARN_ONLY
+                 OFF --error-exitcode=1)
+    _add_switch (CPPCHECK_OPTIONS CPPCHECK_NO_CHECK_STYLE
+                 OFF --enable=style)
+    _add_switch (CPPCHECK_OPTIONS CPPCHECK_CHECK_UNUSED
+                 ON --enable=unusedFunction
+                 OFF --suppress=unusedStructMember)
 
-        list (APPEND CPPCHECK_OPTIONS --error-exitcode=1)
+    _append_each_to_options_with_prefix (CPPCHECK_OPTIONS -I
+                                         LIST
+                                         ${CPPCHECK_INCLUDES})
 
-    endif (NOT CPPCHECK_WARN_ONLY)
+    _append_each_to_options_with_prefix (CPPCHECK_OPTIONS -D
+                                         LIST
+                                         ${CPPCHECK_DEFINES})
 
-    if (NOT CPPCHECK_NO_CHECK_STYLE)
-
-        list (APPEND CPPCHECK_OPTIONS --enable=style)
-
-    endif (NOT CPPCHECK_NO_CHECK_STYLE)
-
-    if (CPPCHECK_CHECK_UNUSED)
-
-        list (APPEND CPPCHECK_OPTIONS --enable=unusedFunction)
-
-    else (CPPCHECK_CHECK_UNUSED)
-
-        list (APPEND CPPCHECK_OPTIONS --suppress=unusedStructMember)
-
-    endif (CPPCHECK_CHECK_UNUSED)
-
-    foreach (_include ${CPPCHECK_INCLUDES})
-
-        list (APPEND CPPCHECK_OPTIONS -I${_include})
-
-    endforeach (_include)
-
-    foreach (_definition ${CPPCHECK_DEFINES})
-
-        list (APPEND CPPCHECK_OPTIONS -D${_definition})
-
-    endforeach ()
-
-    set (EXTRA_ARGS)
+    _get_target_command_attach_point (${TARGET} WHEN)
 
     _cppcheck_add_checks_to_target (${TARGET}
                                     ${WHEN}
@@ -670,28 +452,9 @@ function (cppcheck_sources TARGET)
                                     INCLUDES ${CPPCHECK_INCLUDES}
                                     DEFINES ${CPPCHECK_DEFINES}
                                     CPP_IDENTIFIERS ${CPPCHECK_CPP_IDENTIFIERS}
-                                    FORCE_LANGUAGE ${CPPCHECK_FORCE_LANGUAGE}
-                                    ${EXTRA_ARGS})
+                                    FORCE_LANGUAGE ${CPPCHECK_FORCE_LANGUAGE})
 
 endfunction (cppcheck_sources)
-
-function (_strip_add_custom_target_sources RETURN_SOURCES TARGET)
-
-    get_target_property (_sources ${TARGET} SOURCES)
-    list (GET _sources 0 _first_source)
-    string (FIND "${_first_source}" "/" LAST_SLASH REVERSE)
-    math (EXPR LAST_SLASH "${LAST_SLASH} + 1")
-    string (SUBSTRING "${_first_source}" ${LAST_SLASH} -1 END_OF_SOURCE)
-
-    if (END_OF_SOURCE STREQUAL "${TARGET}")
-
-        list (REMOVE_AT _sources 0)
-
-    endif (END_OF_SOURCE STREQUAL "${TARGET}")
-
-    set (${RETURN_SOURCES} ${_sources} PARENT_SCOPE)
-
-endfunction ()
 
 # cppcheck_target_sources
 #
@@ -717,16 +480,7 @@ function (cppcheck_target_sources TARGET)
 
     _strip_add_custom_target_sources (_files_to_check ${TARGET})
 
-    set (EXTRA_OPTIONS)
-    set (MULTIVALUE_OPTIONS INCLUDES)
-    cmake_parse_arguments (CPPCHECK
-                           ""
-                           ""
-                           "${MULTIVALUE_OPTIONS}"
-                           ${ARGN})
-
     cppcheck_sources (${TARGET}
-                      INCLUDES ${CPPCHECK_INCLUDES}
                       SOURCES ${_files_to_check}
                       ${ARGN})
 

--- a/util/CppCheckUtil.cmake
+++ b/util/CppCheckUtil.cmake
@@ -1,0 +1,326 @@
+# /util/CppCheckUtil.cmake
+#
+# Utility functions for CPPCheck.cmake
+#
+# See LICENCE.md for Copyright information.
+
+function (_filter_out_generated_sources RESULT_VARIABLE)
+
+    set (FILTER_OUT_MUTLIVAR_OPTIONS SOURCES)
+
+    cmake_parse_arguments (FILTER_OUT
+                           ""
+                           ""
+                           "${FILTER_OUT_MUTLIVAR_OPTIONS}"
+                           ${ARGN})
+
+    set (${RESULT_VARIABLE} PARENT_SCOPE)
+    set (FILTERED_SOURCES)
+
+    foreach (SOURCE ${FILTER_OUT_SOURCES})
+
+        get_property (SOURCE_IS_GENERATED
+                      SOURCE ${SOURCE}
+                      PROPERTY GENERATED)
+
+        if (NOT SOURCE_IS_GENERATED)
+
+            list (APPEND FILTERED_SOURCES ${SOURCE})
+
+        endif (NOT SOURCE_IS_GENERATED)
+
+    endforeach ()
+
+    set (${RESULT_VARIABLE} ${FILTERED_SOURCES} PARENT_SCOPE)
+
+endfunction (_filter_out_generated_sources)
+
+function (_append_to_global_property_unique PROPERTY ITEM)
+
+    get_property (GLOBAL_PROPERTY
+                  GLOBAL
+                  PROPERTY ${PROPERTY})
+
+    set (LIST_CONTAINS_ITEM FALSE)
+
+    foreach (LIST_ITEM ${GLOBAL_PROPERTY})
+
+        if (LIST_ITEM STREQUAL ${ITEM})
+
+            set (LIST_CONTAINS_ITEM TRUE)
+            break ()
+
+        endif (LIST_ITEM STREQUAL ${ITEM})
+
+    endforeach ()
+
+    if (NOT LIST_CONTAINS_ITEM)
+
+        set_property (GLOBAL
+                      APPEND
+                      PROPERTY ${PROPERTY}
+                      ${ITEM})
+
+    endif (NOT LIST_CONTAINS_ITEM)
+
+endfunction ()
+
+function (_append_to_global_property PROPERTY)
+
+    cmake_parse_arguments (APPEND
+                           ""
+                           ""
+                           "LIST"
+                           ${ARGN})
+
+    foreach (ITEM ${APPEND_LIST})
+
+        set_property (GLOBAL
+                      APPEND
+                      PROPERTY ${PROPERTY}
+                      ${ITEM})
+
+    endforeach ()
+
+endfunction (_append_to_global_property)
+
+function (_append_each_to_options_with_prefix MAIN_LIST PREFIX)
+
+    cmake_parse_arguments (APPEND
+                           ""
+                           ""
+                           "LIST"
+                           ${ARGN})
+
+    foreach (ITEM ${APPEND_LIST})
+
+        list (APPEND ${MAIN_LIST} ${PREFIX}${ITEM})
+
+    endforeach ()
+
+    set (${MAIN_LIST} ${${MAIN_LIST}} PARENT_SCOPE)
+
+endfunction (_append_each_to_options_with_prefix)
+
+function (_add_switch ALL_OPTIONS OPTION_NAME)
+
+    set (ADD_SWITCH_SINGLEVAR_ARGS ON OFF)
+    cmake_parse_arguments (ADD_SWITCH
+                           ""
+                           "${ADD_SWITCH_SINGLEVAR_ARGS}"
+                           ""
+                           ${ARGN})
+
+    if (${OPTION_NAME})
+
+        list (APPEND ${ALL_OPTIONS} ${ADD_SWITCH_ON})
+
+    else (DEFINED ${OPTION_NAME})
+
+        list (APPEND ${ALL_OPTIONS} ${ADD_SWITCH_OFF})
+
+    endif (${OPTION_NAME})
+
+    set (${ALL_OPTIONS} ${${ALL_OPTIONS}} PARENT_SCOPE)
+
+endfunction (_add_switch)
+
+function (_strip_add_custom_target_sources RETURN_SOURCES TARGET)
+
+    get_target_property (_sources ${TARGET} SOURCES)
+    list (GET _sources 0 _first_source)
+    string (FIND "${_first_source}" "/" LAST_SLASH REVERSE)
+    math (EXPR LAST_SLASH "${LAST_SLASH} + 1")
+    string (SUBSTRING "${_first_source}" ${LAST_SLASH} -1 END_OF_SOURCE)
+
+    if (END_OF_SOURCE STREQUAL "${TARGET}")
+
+        list (REMOVE_AT _sources 0)
+
+    endif (END_OF_SOURCE STREQUAL "${TARGET}")
+
+    set (${RETURN_SOURCES} ${_sources} PARENT_SCOPE)
+
+endfunction ()
+
+function (_get_target_command_attach_point TARGET ATTACH_POINT_RETURN)
+
+    # Figure out if this target is linkable. If it is a UTILITY
+    # target then we need to run the checks at the PRE_BUILD stage.
+    set (_ATTACH_POINT PRE_LINK)
+
+    get_property (TARGET_TYPE
+                  TARGET ${TARGET}
+                  PROPERTY TYPE)
+
+    if (TARGET_TYPE STREQUAL "UTILITY")
+
+        set (_ATTACH_POINT PRE_BUILD)
+
+    endif (TARGET_TYPE STREQUAL "UTILITY")
+
+    set (${ATTACH_POINT_RETURN} ${_ATTACH_POINT} PARENT_SCOPE)
+
+endfunction (_get_target_command_attach_point)
+
+function (_handle_check_generated_option PREFIX SOURCES_RETURN)
+
+    cmake_parse_arguments (HANDLE_CHECK_GENERATED
+                           ""
+                           ""
+                           "SOURCES"
+                           ${ARGN})
+
+    # First case: We're checking generated sources, so
+    # we can just check all passed in sources.
+    if (${PREFIX}_CHECK_GENERATED)
+
+        set (_FILTERED_SOURCES ${HANDLE_CHECK_GENERATED_SOURCES})
+
+    # Second case: We only want to check real sources,
+    # so filter out generated ones.
+    else (${PREFIX}_CHECK_GENERATED)
+
+        _filter_out_generated_sources (_FILTERED_SOURCES
+                                       SOURCES
+                                       ${HANDLE_CHECK_GENERATED_SOURCES})
+
+    endif (${PREFIX}_CHECK_GENERATED)
+
+    set (${SOURCES_RETURN} ${_FILTERED_SOURCES} PARENT_SCOPE)
+
+endfunction (_handle_check_generated_option)
+
+function (_assert_set VARIABLE)
+
+    if (NOT VARIABLE)
+
+        message (FATAL_ERROR "${ARGN}")
+
+    endif (NOT VARIABLE)
+
+endfunction (_assert_set)
+
+function (_polysquare_forward_options PREFIX RETURN_LIST_NAME)
+
+    set (FORWARD_OPTION_ARGS "")
+    set (FORWARD_SINGLEVAR_ARGS "")
+    set (FORWARD_MULTIVAR_ARGS
+         OPTION_ARGS
+         SINGLEVAR_ARGS
+         MULTIVAR_ARGS)
+
+    cmake_parse_arguments (FORWARD
+                           "${FORWARD_OPTION_ARGS}"
+                           "${FORWARD_SINGLEVAR_ARGS}"
+                           "${FORWARD_MULTIVAR_ARGS}"
+                           ${ARGN})
+
+    # Temporary accumulation of variables to forward
+    set (RETURN_LIST)
+
+    # Option args - just forward the value of each set ${REFIX_OPTION_ARG}
+    # as this will be set to the option or to ""
+    foreach (OPTION_ARG ${FORWARD_OPTION_ARGS})
+
+        set (PREFIXED_OPTION_ARG ${PREFIX}_${OPTION_ARG})
+
+        if (${PREFIXED_OPTION_ARG})
+
+             list (APPEND RETURN_LIST ${OPTION_ARG})
+
+        endif (${PREFIXED_OPTION_ARG})
+
+    endforeach ()
+
+    # Single-variable args - add the name of the argument and its value to
+    # the return list
+    foreach (SINGLEVAR_ARG ${FORWARD_SINGLEVAR_ARGS})
+
+        set (PREFIXED_SINGLEVAR_ARG ${PREFIX}_${SINGLEVAR_ARG})
+        list (APPEND RETURN_LIST ${SINGLEVAR_ARG})
+        list (APPEND RETURN_LIST ${${PREFIXED_SINGLEVAR_ARG}})
+
+    endforeach ()
+
+    # Multi-variable args - add the name of the argument and all its values
+    # to the return-list
+    foreach (MULTIVAR_ARG ${FORWARD_MULTIVAR_ARGS})
+
+        set (PREFIXED_MULTIVAR_ARG ${PREFIX}_${MULTIVAR_ARG})
+        list (APPEND RETURN_LIST ${MULTIVAR_ARG})
+
+        foreach (VALUE ${${PREFIXED_MULTIVAR_ARG}})
+
+            list (APPEND RETURN_LIST ${VALUE})
+
+        endforeach ()
+
+    endforeach ()
+
+    set (${RETURN_LIST_NAME} ${RETURN_LIST} PARENT_SCOPE)
+
+endfunction ()
+
+function (_sort_sources_to_languages C_SOURCES CXX_SOURCES)
+
+    set (SORT_SOURCES_SINGLEVAR_OPTIONS FORCE_LANGUAGE)
+    set (SORT_SOURCES_MULTIVAR_OPTIONS
+         SOURCES
+         CPP_IDENTIFIERS
+         INCLUDES)
+    cmake_parse_arguments (SORT_SOURCES
+                           ""
+                           "${SORT_SOURCES_SINGLEVAR_OPTIONS}"
+                           "${SORT_SOURCES_MULTIVAR_OPTIONS}"
+                           ${ARGN})
+
+    _polysquare_forward_options (SORT_SOURCES
+                                 DETERMINE_LANG_OPTIONS
+                                 SINGLEVAR_ARGS FORCE_LANGUAGE
+                                 MULTIVAR_ARGS CPP_IDENTIFIERS INCLUDES)
+
+    foreach (SOURCE ${SORT_SOURCES_SOURCES})
+
+        set (LANGUAGE ${SORT_SOURCES_FORCE_LANGUAGE})
+
+        if (NOT LANGUAGE)
+
+            set (INCLUDES ${SORT_SOURCES_INCLUDES})
+            set (CPP_IDENTIFIERS ${SORT_SOURCES_CPP_IDENTIFIERS})
+            polysquare_determine_language_for_source (${SOURCE}
+                                                      LANGUAGE
+                                                      SOURCE_WAS_HEADER
+                                                      ${DETERMINE_LANG_OPTIONS})
+
+            # Scan this source for headers, we'll need them later
+            if (NOT SOURCE_WAS_HEADER)
+
+                polysquare_scan_source_for_headers (SOURCE ${SOURCE}
+                                                    ${DETERMINE_LANG_OPTIONS})
+
+            endif (NOT SOURCE_WAS_HEADER)
+
+        endif (NOT LANGUAGE)
+
+        list (FIND LANGUAGE "C" C_INDEX)
+        list (FIND LANGUAGE "CXX" CXX_INDEX)
+
+        if (NOT C_INDEX EQUAL -1)
+
+            list (APPEND _C_SOURCES ${SOURCE})
+
+        endif (NOT C_INDEX EQUAL -1)
+
+        if (NOT CXX_INDEX EQUAL -1)
+
+            list (APPEND _CXX_SOURCES ${SOURCE})
+
+        endif (NOT CXX_INDEX EQUAL -1)
+
+    endforeach ()
+
+    set (${C_SOURCES} ${_C_SOURCES} PARENT_SCOPE)
+    set (${CXX_SOURCES} ${_CXX_SOURCES} PARENT_SCOPE)
+
+endfunction (_sort_sources_to_languages)


### PR DESCRIPTION
Create and use the following functions:
1. `_polysquare_forward_options` forwards `cmake_parse_arguments` options and stores them within `RETURN_LIST_NAME`.
2. `_sort_sources_to_languages` takes a list of `SOURCES`, parses them and stores them in `C_SOURCES` and `CXX_SOURCES`.
3. `_handle_check_generated_option` removes generated sources if `CHECK_GENERATED` is set.
4. `_append_to_global_property` appends items in a list to a global property.
5. `_assert_set` checks that a variable is set and if not aborts with a message
6. `_add_switch` appends a command line switch to a specified list of options based on an option passed to the function.
7. `_append_each_to_options_with_prefix` appends each item in a list to a set of options, giving each a prefix.

Also remove needless checks, dead code, etc.
